### PR TITLE
feat: add headers to lastfm fetch

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -35,7 +35,13 @@ export class PlaylistGenerator {
 
     for (let page = 1; found.size < (amount ?? 0); page++) {
       const response = await fetch(
-        `https://www.last.fm/player/station/user/${username}/${type}?page=${page}`
+        `https://www.last.fm/player/station/user/${username}/${type}?page=${page}`,
+        {
+          headers: {
+            Accept: "application/json",
+            "User-Agent": "lastfm-playlists",
+          },
+        }
       );
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- send explicit Accept and User-Agent headers when fetching Last.fm tracks

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `curl -H "Accept: application/json" -H "User-Agent: lastfm-playlists" https://www.last.fm/player/station/user/she11sh0cked/mix?page=1 -I` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b574dfedfc8327960ca4991c19d88a