### PR TITLE
Fix separate playlist configuration and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ web_modules/
 
 # TypeScript cache
 
-\*.tsbuildinfo
+*.tsbuildinfo
 
 # Optional npm cache directory
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ services:
       - LASTFM_USERNAMES=she11sh0cked
       - LASTFM_PLAYLISTS=library,mix,recommended
       - AMOUNT=100
-      - ENABLE_BLENDED=true
-      - ENEABLE_SEPARATE=true
+      - ENABLE_BLEND=true
+      - ENABLE_SEPARATE=true
       - CACHE_FILE=/config/cache.json # optional: persist the song cache to a file
       - CACHE_MAX_SIZE=1MB # optional: limit the cache file size to 1MB
       - SPOTIFY_CLIENT_ID=your-client-id
@@ -40,7 +40,7 @@ docker run -d \
   -e LASTFM_USERNAMES=she11sh0cked \
   -e LASTFM_PLAYLISTS=library,mix,recommended \
   -e AMOUNT=100 \
-  -e ENABLE_BLENDED=true \
+  -e ENABLE_BLEND=true \
   -e ENABLE_SEPARATE=true \
   -e CACHE_FILE=/config/cache.json \
   -e CACHE_MAX_SIZE=1MB \
@@ -62,8 +62,8 @@ docker run -d \
 | `-e LASTFM_USERNAMES=USERNAME`                | Your Last.fm username or a comma separated list of usernames.                          |
 | `-e LASTFM_PLAYLISTS=mix,library,recommended` | The playlists to create. Available: mix, library, recommended.                         |
 | `-e AMOUNT=100`                               | The amount of songs to add to the playlists.                                           |
-| `-e ENABLE_BLENDED=true`                      | Whether to create blended playlists from all users' tracks.                            |
-| `-e ENABLE_SEPARATE=true`                     | Whether to create seperate playlists for each user.                                    |
+| `-e ENABLE_BLEND=true`                        | Whether to create blended playlists from all users' tracks.                            |
+| `-e ENABLE_SEPARATE=true`                     | Whether to create separate playlists for each user.                                    |
 | `-e CACHE_FILE=/config/cache.json`            | Path to the file where song lookup cache will be stored.                               |
 | `-e CACHE_MAX_SIZE=1MB`                       | Maximum size of the cache file. Supports human-readable formats (e.g. '1MB', '500KB'). |
 | `-e SPOTIFY_CLIENT_ID=CLIENT_ID`              | Your Spotify client ID.                                                                |

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,11 +132,11 @@ const config = convict({
     default: true,
     env: "ENABLE_BLEND",
   },
-  enableSeperate: {
-    doc: "Whether to create seperate playlists for each user.",
+  enableSeparate: {
+    doc: "Whether to create separate playlists for each user.",
     format: Boolean,
     default: true,
-    env: "ENABLE_SEPERATE",
+    env: "ENABLE_SEPARATE",
   },
   cache: {
     file: {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -196,7 +196,7 @@ export class PlaylistGenerator {
     }
   }
 
-  async createSeperatePlaylists(
+  async createSeparatePlaylists(
     username: Config["usernames"][number],
     type: Config["playlists"][number],
     amount?: Config["amount"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,11 @@ const songCache = new PersistentCache<string | null>(
   config.get("cache.maxSize")
 );
 
-if (config.get("enableSeperate")) {
+if (config.get("enableSeparate")) {
   // Create individual playlists for each user
   for await (const username of config.get("usernames")) {
     for await (const playlist of config.get("playlists")) {
-      await generator.createSeperatePlaylists(
+      await generator.createSeparatePlaylists(
         username,
         playlist,
         config.get("amount"),


### PR DESCRIPTION
## Summary
- fix typos in docs and examples for ENABLE_BLEND and ENABLE_SEPARATE env vars
- rename `enableSeperate` to `enableSeparate` in config and code
- ignore TypeScript build info files
- correct spacing for ENABLE_BLEND parameter in README

## Testing
- `bunx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc750904832781d66069ce85fa41